### PR TITLE
Fix ELB properties:

### DIFF
--- a/Test.json
+++ b/Test.json
@@ -42,16 +42,16 @@
         "CrossZone": "true",
         "HealthCheck": {
           "HealthyThreshold": "5",
-          "Interval": "10",
-          "Target": "HTTP",
-          "Timeout": "60",
-          "UnhealthyThreshold": "2"
+          "Interval": "60",
+          "Target": "HTTP:80/",
+          "Timeout": "10",
+          "UnhealthyThreshold": "3"
         },
-        "Listeners": {
+        "Listeners": [{
           "LoadBalancerPort": "80",
-          "instanceport" : "80",
+          "InstancePort" : "80",
           "Protocol": "HTTP"
-        },
+        }],
         "AvailabilityZones" : { "Fn::GetAZs" : "" }
       }
     },


### PR DESCRIPTION
```
HealthCheck target consist of protocol, port and path. Example: "HTTP:80/"
HealthCheck timeout must be smaller than interval
```
